### PR TITLE
Add variability range attributes

### DIFF
--- a/doc/schemadoc/EPD_DataSet.html
+++ b/doc/schemadoc/EPD_DataSet.html
@@ -2694,16 +2694,16 @@
     <td class="fieldname fieldname_epd24" style="padding-left: 40px;">epd24:variability</td>
     <td class="fieldname fieldname_epd24">o</td>
     <td class="fieldname fieldname_epd24">[0,1]</td>
-    <td class="fieldname fieldname_epd24"/>
+    <td class="fieldname fieldname_epd24"></td>
     <td class="fieldname fieldname_epd24">Angaben zur Spanne/Variabilität der LCIA-Resultate, bspw. falls es sich bei den Resultate um Mittel über verschiedene Produkte oder Produktionsstätten handelt.
     </td>
     <td class="fieldname fieldname_epd24">Information on the range/variability of the LCIA results, e.g. if the results are averages across different products or production sites.
     </td>
-    <td class="fieldname fieldname_epd24"/>
-    <td class="fieldname fieldname_epd24"/>
-    <td class="fieldname fieldname_epd24"/>
-    <td class="fieldname fieldname_epd24"/>
-    <td class="fieldname fieldname_epd24"/>
+    <td class="fieldname fieldname_epd24"></td>
+    <td class="fieldname fieldname_epd24"></td>
+    <td class="fieldname fieldname_epd24"></td>
+    <td class="fieldname fieldname_epd24"></td>
+    <td class="fieldname fieldname_epd24"></td>
   </tr>
   <tr>
     <td class="fieldname fieldname_epd24" style="padding-left: 50px;">Herstellervariabilität</td>
@@ -2711,14 +2711,14 @@
     <td class="fieldname fieldname_epd24" style="padding-left: 50px;">epd24:manufacturerVariability</td>
     <td class="fieldname fieldname_epd24">m</td>
     <td class="fieldname fieldname_epd24">[1]</td>
-    <td class="fieldname fieldname_epd24"/>
+    <td class="fieldname fieldname_epd24"></td>
     <td class="fieldname fieldname_epd24">Variabilität bzgl. verschiedener Hersteller/Produktionssttätten</td>
     <td class="fieldname fieldname_epd24">The varibility across manufacturers/sites</td>
-    <td class="fieldname fieldname_epd24"/>
-    <td class="fieldname fieldname_epd24"/>
-    <td class="fieldname fieldname_epd24"/>
-    <td class="fieldname fieldname_epd24"/>
-    <td class="fieldname fieldname_epd24"/>
+    <td class="fieldname fieldname_epd24"></td>
+    <td class="fieldname fieldname_epd24"></td>
+    <td class="fieldname fieldname_epd24"></td>
+    <td class="fieldname fieldname_epd24"></td>
+    <td class="fieldname fieldname_epd24"></td>
   </tr>
   <tr>
     <td class="fieldname fieldname_epd24" style="padding-left: 60px;">Art der Variabilität</td>
@@ -2733,43 +2733,11 @@
     </td>
     <td class="fieldname fieldname_epd24">Angaben zur genauen Art der Variabilität</td>
     <td class="fieldname fieldname_epd24">Definition of the type of variability</td>
-    <td class="fieldname fieldname_epd24"/>
-    <td class="fieldname fieldname_epd24"/>
-    <td class="fieldname fieldname_epd24"/>
-    <td class="fieldname fieldname_epd24"/>
-    <td class="fieldname fieldname_epd24"/>
-  </tr>
-  <tr>
-    <td class="fieldname fieldname_epd24" style="padding-left: 50px;">Produktvariabilität</td>
-    <td class="fieldname fieldname_epd24" style="padding-left: 50px;">Product variability</td>
-    <td class="fieldname fieldname_epd24" style="padding-left: 50px;">epd24:productVariability</td>
-    <td class="fieldname fieldname_epd24">m</td>
-    <td class="fieldname fieldname_epd24">[1]</td>
-    <td class="fieldname fieldname_epd24"/>
-    <td class="fieldname fieldname_epd24">Variabilität bzgl. verschiedener Produkte/Produkttypen</td>
-    <td class="fieldname fieldname_epd24"/>
-    <td class="fieldname fieldname_epd24"/>
-    <td class="fieldname fieldname_epd24"/>
-    <td class="fieldname fieldname_epd24"/>
-    <td class="fieldname fieldname_epd24"/>
-    <td class="fieldname fieldname_epd24"/>
-  </tr>
-  <tr>
-    <td class="fieldname fieldname_epd24" style="padding-left: 60px;">Art der Variabilität</td>
-    <td class="fieldname fieldname_epd24" style="padding-left: 60px;">Type of variability</td>
-    <td class="fieldname fieldname_epd24" style="padding-left: 60px;">@epd24:type</td>
-    <td class="fieldname fieldname_epd24">m</td>
-    <td class="fieldname fieldname_epd24">[1]</td>
-    <td class="fieldname fieldname_epd24">
-      <i>Single product</i><br/> <i>Range of products where variability is described</i>
-    </td>
-    <td class="fieldname fieldname_epd24">Angabe zur Art der Variabilität</td>
-    <td class="fieldname fieldname_epd24">Information on the type of variability</td>
-    <td class="fieldname fieldname_epd24"/>
-    <td class="fieldname fieldname_epd24"/>
-    <td class="fieldname fieldname_epd24"/>
-    <td class="fieldname fieldname_epd24"/>
-    <td class="fieldname fieldname_epd24"/>
+    <td class="fieldname fieldname_epd24"></td>
+    <td class="fieldname fieldname_epd24"></td>
+    <td class="fieldname fieldname_epd24"></td>
+    <td class="fieldname fieldname_epd24"></td>
+    <td class="fieldname fieldname_epd24"></td>
   </tr>
   <tr>
     <td class="fieldname fieldname_epd24" style="padding-left: 60px;">Variation</td>
@@ -2782,11 +2750,108 @@
     </td>
     <td class="fieldname fieldname_epd24">Die Variabilität angegeben in Prozent.</td>
     <td class="fieldname fieldname_epd24">The variability given in percent.</td>
-    <td class="fieldname fieldname_epd24"/>
-    <td class="fieldname fieldname_epd24"/>
-    <td class="fieldname fieldname_epd24"/>
-    <td class="fieldname fieldname_epd24"/>
-    <td class="fieldname fieldname_epd24"/>
+    <td class="fieldname fieldname_epd24"></td>
+    <td class="fieldname fieldname_epd24"></td>
+    <td class="fieldname fieldname_epd24"></td>
+    <td class="fieldname fieldname_epd24"></td>
+    <td class="fieldname fieldname_epd24"></td>
+  </tr>
+  <tr>
+    <td class="fieldname fieldname_epd24" style="padding-left: 60px;">Variationsspanne</td>
+    <td class="fieldname fieldname_epd24" style="padding-left: 60px;">Variation range</td>
+    <td class="fieldname fieldname_epd24" style="padding-left: 60px;">@epd24:variationRange</td>
+    <td class="fieldname fieldname_epd24">0</td>
+    <td class="fieldname fieldname_epd24">[0,1]</td>
+    <td class="fieldname fieldname_epd24">
+      Restricted <code>xs:string</code>:
+      <ul>
+        <li>A - less than 2,5%</li>
+        <li>B - between 2,5% and 10%</li>
+        <li>C - between 10% and 25%</li>
+        <li>D - between 25% and 50%</li>
+        <li>E - more than 50%</li>
+      </ul>
+    </td>
+    <td class="fieldname fieldname_epd24">Grob abgeschätzte Angabe der Variation (s. ISO 14044 Annex B)</td>
+    <td class="fieldname fieldname_epd24">Rough estimate of the variation (c.f. ISO 14044 Annex B)</td>
+    <td class="fieldname fieldname_epd24"></td>
+    <td class="fieldname fieldname_epd24"></td>
+    <td class="fieldname fieldname_epd24"></td>
+    <td class="fieldname fieldname_epd24"></td>
+    <td class="fieldname fieldname_epd24"></td>
+  </tr>
+  <tr>
+    <td class="fieldname fieldname_epd24" style="padding-left: 50px;">Produktvariabilität</td>
+    <td class="fieldname fieldname_epd24" style="padding-left: 50px;">Product variability</td>
+    <td class="fieldname fieldname_epd24" style="padding-left: 50px;">epd24:productVariability</td>
+    <td class="fieldname fieldname_epd24">m</td>
+    <td class="fieldname fieldname_epd24">[1]</td>
+    <td class="fieldname fieldname_epd24"></td>
+    <td class="fieldname fieldname_epd24">Variabilität bzgl. verschiedener Produkte/Produkttypen</td>
+    <td class="fieldname fieldname_epd24"></td>
+    <td class="fieldname fieldname_epd24"></td>
+    <td class="fieldname fieldname_epd24"></td>
+    <td class="fieldname fieldname_epd24"></td>
+    <td class="fieldname fieldname_epd24"></td>
+    <td class="fieldname fieldname_epd24"></td>
+  </tr>
+  <tr>
+    <td class="fieldname fieldname_epd24" style="padding-left: 60px;">Art der Variabilität</td>
+    <td class="fieldname fieldname_epd24" style="padding-left: 60px;">Type of variability</td>
+    <td class="fieldname fieldname_epd24" style="padding-left: 60px;">@epd24:type</td>
+    <td class="fieldname fieldname_epd24">m</td>
+    <td class="fieldname fieldname_epd24">[1]</td>
+    <td class="fieldname fieldname_epd24">
+      <i>Single product</i><br/> <i>Range of products where variability is described</i>
+    </td>
+    <td class="fieldname fieldname_epd24">Angabe zur Art der Variabilität</td>
+    <td class="fieldname fieldname_epd24">Information on the type of variability</td>
+    <td class="fieldname fieldname_epd24"></td>
+    <td class="fieldname fieldname_epd24"></td>
+    <td class="fieldname fieldname_epd24"></td>
+    <td class="fieldname fieldname_epd24"></td>
+    <td class="fieldname fieldname_epd24"></td>
+  </tr>
+  <tr>
+    <td class="fieldname fieldname_epd24" style="padding-left: 60px;">Variation</td>
+    <td class="fieldname fieldname_epd24" style="padding-left: 60px;">Variation</td>
+    <td class="fieldname fieldname_epd24" style="padding-left: 60px;">@epd24:variation</td>
+    <td class="fieldname fieldname_epd24">0</td>
+    <td class="fieldname fieldname_epd24">[0,1]</td>
+    <td class="fieldname fieldname_epd24">
+      <a target="_blank" href="ILCD_Common_DataTypes.html#Perc">common:Perc</a>
+    </td>
+    <td class="fieldname fieldname_epd24">Die Variabilität angegeben in Prozent.</td>
+    <td class="fieldname fieldname_epd24">The variability given in percent.</td>
+    <td class="fieldname fieldname_epd24"></td>
+    <td class="fieldname fieldname_epd24"></td>
+    <td class="fieldname fieldname_epd24"></td>
+    <td class="fieldname fieldname_epd24"></td>
+    <td class="fieldname fieldname_epd24"></td>
+  </tr>
+  <tr>
+    <td class="fieldname fieldname_epd24" style="padding-left: 60px;">Variationsspanne</td>
+    <td class="fieldname fieldname_epd24" style="padding-left: 60px;">Variation range</td>
+    <td class="fieldname fieldname_epd24" style="padding-left: 60px;">@epd24:variationRange</td>
+    <td class="fieldname fieldname_epd24">0</td>
+    <td class="fieldname fieldname_epd24">[0,1]</td>
+    <td class="fieldname fieldname_epd24">
+      Restricted <code>xs:string</code>:
+      <ul>
+        <li>A - less than 2,5%</li>
+        <li>B - between 2,5% and 10%</li>
+        <li>C - between 10% and 25%</li>
+        <li>D - between 25% and 50%</li>
+        <li>E - more than 50%</li>
+      </ul>
+    </td>
+    <td class="fieldname fieldname_epd24">Grob abgeschätzte Angabe der Variation (s. ISO 14044 Annex B)</td>
+    <td class="fieldname fieldname_epd24">Rough estimate of the variation (c.f. ISO 14044 Annex B)</td>
+    <td class="fieldname fieldname_epd24"></td>
+    <td class="fieldname fieldname_epd24"></td>
+    <td class="fieldname fieldname_epd24"></td>
+    <td class="fieldname fieldname_epd24"></td>
+    <td class="fieldname fieldname_epd24"></td>
   </tr>
   <tr>
     <td class="fieldname fieldname_epd24" style="padding-left: 50px;">Variabilitätsbeschreibung</td>
@@ -2801,11 +2866,11 @@
     </td>
     <td class="fieldname fieldname_epd24">Additional descriptions, explanations and comments, e.g. on significance and methodology
     </td>
-    <td class="fieldname fieldname_epd24"/>
-    <td class="fieldname fieldname_epd24"/>
-    <td class="fieldname fieldname_epd24"/>
-    <td class="fieldname fieldname_epd24"/>
-    <td class="fieldname fieldname_epd24"/>
+    <td class="fieldname fieldname_epd24"></td>
+    <td class="fieldname fieldname_epd24"></td>
+    <td class="fieldname fieldname_epd24"></td>
+    <td class="fieldname fieldname_epd24"></td>
+    <td class="fieldname fieldname_epd24"></td>
   </tr>
   <tr>
     <td class="subsection" style="padding-left: 20px;font-style: italic;">Datenquellen und Repräsentativität</td>

--- a/sample_data/processes/EPDv1.3_example_57a4ae65-d305-421e-b21f-a3f0c35b8abe.xml
+++ b/sample_data/processes/EPDv1.3_example_57a4ae65-d305-421e-b21f-a3f0c35b8abe.xml
@@ -175,8 +175,8 @@
             <common:other>
                 <epd:subType>specific dataset</epd:subType>
                 <epd24:variability>
-                   <epd24:manufacturerVariability epd24:type="Single production site" epd24:variation="5"/>
-                   <epd24:productVariability epd24:type="Range of products where variability is described" epd24:variation="20"/>
+                   <epd24:manufacturerVariability epd24:type="Single production site" epd24:variation="5" epd24:variationRange="B - between 2,5% and 10%"/>
+                   <epd24:productVariability epd24:type="Range of products where variability is described" epd24:variation="20" epd24:variationRange="C - between 10% and 25%"/>
                    <epd24:variabilityDescription xml:lang="en">A sensitivity analysis is performed to assess the representativeness of the representative product. The environmental impact results for the individual products have maximum positive difference of 23% (product A) when compared with the representative product, in the Acidification Potential (AP) impact category.</epd24:variabilityDescription>
                    <epd24:variabilityDescription xml:lang="de">A sensitivity analysis is performed to assess the representativeness of the representative product. The environmental impact results for the individual products have maximum positive difference of 23% (product A) when compared with the representative product, in the Acidification Potential (AP) impact category.</epd24:variabilityDescription>
                 </epd24:variability>

--- a/schemas/EPD_Extensions_2024.xsd
+++ b/schemas/EPD_Extensions_2024.xsd
@@ -165,8 +165,8 @@
    <xs:element name="variability">
       <xs:complexType>
          <xs:sequence>
-            <xs:element ref="manufacturerVariability" minOccurs="1" maxOccurs="1"/>
-            <xs:element ref="productVariability" minOccurs="1" maxOccurs="1"/>
+            <xs:element ref="manufacturerVariability" minOccurs="0" maxOccurs="1"/>
+            <xs:element ref="productVariability" minOccurs="0" maxOccurs="1"/>
             <xs:element name="variabilityDescription" type="common:FTMultiLang" minOccurs="0" maxOccurs="unbounded"/>
             <xs:any namespace="##other" minOccurs="0" maxOccurs="unbounded"/>
          </xs:sequence>

--- a/schemas/EPD_Extensions_2024.xsd
+++ b/schemas/EPD_Extensions_2024.xsd
@@ -183,6 +183,8 @@
             <xs:any namespace="##other" minOccurs="0" maxOccurs="unbounded"/>
          </xs:sequence>
          <xs:attribute name="type" type="ManufacturerVariabilityValues" use="required"/>
+         <xs:attribute ref="epd24:variation" use="optional"/>
+         <xs:attribute ref="epd24:variationRange" use="optional"/>
          <xs:anyAttribute/>
       </xs:complexType>
    </xs:element>
@@ -193,12 +195,14 @@
             <xs:any namespace="##other" minOccurs="0" maxOccurs="unbounded"/>
          </xs:sequence>
          <xs:attribute name="type" type="ProductVariabilityValues" use="required"/>
-         <xs:attribute ref="variation" use="optional"/>
+         <xs:attribute ref="epd24:variation" use="optional"/>
+         <xs:attribute ref="epd24:variationRange" use="optional"/>
          <xs:anyAttribute/>
       </xs:complexType>
    </xs:element>
 
    <xs:attribute name="variation" type="common:Perc"/>
+   <xs:attribute name="variationRange" type="epd24:VariationRange"/>
 
    <xs:element name="scenarioData">
       <xs:complexType>
@@ -250,16 +254,27 @@
    
    <xs:simpleType name="ManufacturerVariabilityValues">
       <xs:restriction base="xs:string">
-         <xs:enumeration value="Single production site"></xs:enumeration>
-         <xs:enumeration value="Single manufacturer with multiple production sites"></xs:enumeration>
-         <xs:enumeration value="Multiple manufacturers"></xs:enumeration>
+         <xs:enumeration value="Single production site"/>
+         <xs:enumeration value="Single manufacturer with multiple production sites"/>
+         <xs:enumeration value="Multiple manufacturers"/>
       </xs:restriction>
    </xs:simpleType>
 
    <xs:simpleType name="ProductVariabilityValues">
       <xs:restriction base="xs:string">
-         <xs:enumeration value="Single product"></xs:enumeration>
-         <xs:enumeration value="Range of products where variability is described"></xs:enumeration>
+         <xs:enumeration value="Single product"/>
+         <xs:enumeration value="Range of products where variability is described"/>
+      </xs:restriction>
+   </xs:simpleType>
+
+   <xs:simpleType name="VariationRange">
+      <xs:restriction base="xs:string">
+<!--         modelled after ISO 14044 Annex B-->
+         <xs:enumeration value="A - less than 2,5%"/>
+         <xs:enumeration value="B - between 2,5% and 10%"/>
+         <xs:enumeration value="C - between 10% and 25%"/>
+         <xs:enumeration value="D - between 25% and 50%"/>
+         <xs:enumeration value="E - more than 50%"/>
       </xs:restriction>
    </xs:simpleType>
 


### PR DESCRIPTION
This PR ensures that variation can be declared both as exact percentage value and a rough estimate via `ISO 14044 Annex B` ranges.

The ranges are implemented as string enums.

Adresses issue #17 